### PR TITLE
parse aws credentials and region from aws-cli configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,9 @@ Tool to pull list of files from the s3 downloads.dlang.org bucket
 and generate the appropriate index.html pages to allow the
 bucket to be used as a website.
 
-It expects a `config.json` file in the form:
-
-```
-{
-    "aws" : {
-        "key"    : "<aws access key>",
-        "secret" : "<aws secret key>",
-        "endpoint" : "s3-us-west-2.amazonaws.com"
-    },
-
-    "s3bucket" : "downloads.dlang.org",
-
-    "base_dir" : "/media/scratch/ddo-upload"
-}
-```
+Loads aws credentials and default region from ~/.aws/credentials and
+~/.aws/config, i.e. where the aws-cli stores it's information.
+See [Named Profiles - AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html) for more info.
 
 How to build
 ----------
@@ -25,11 +13,12 @@ How to build
 make
 ```
 
-How to build
+How to generate
 ----------
 
 ```
-./src/build-gen-index <command>
+./src/build-gen-index --help
+./src/build-gen-index --command <command>
 ```
 
 Available commands:
@@ -38,9 +27,8 @@ Available commands:
 - `generate`: generate the HTML index pages
 
 Multiple commands can be combined
-
 ```
-./src/build-gen-index s3_index generate
+./src/build-gen-index --command s3_index --command generate
 ```
 
 How to deploy

--- a/src/config.d
+++ b/src/config.d
@@ -1,31 +1,67 @@
 module config;
 
+import std.algorithm.iteration : filter, map, splitter;
+import std.algorithm.searching : find, startsWith;
+import std.exception : enforce;
 import std.json;
-import std.file;
+import std.process : environment;
+import std.range : empty;
+import std.stdio;
+import std.string : format, strip, stripRight;
+import std.typecons : tuple, Tuple;
 
 struct Config
 {
     string aws_key;
     string aws_secret;
     string aws_endpoint;
-
-    string s3_bucket;
 }
 
-
-Config load_config(string filename)
+auto getIniSection(string path, string section)
 {
-    string contents = cast(string)read(filename);
+    auto lines = File(path, "r")
+        .byLine
+        .find!(ln => ln.strip == section);
+    if (lines.empty)
+        lines = File(path, "r")
+            .byLine
+            .find!(ln => ln.strip == "[default]");
+    enforce(!lines.empty, "Failed to find ini section "~section~" in "~path~".");
+    lines.popFront;
+    return lines.map!readIniLine;
+}
 
-    JSONValue jv = parseJSON(contents);
+Tuple!(const(char)[], const(char)[]) readIniLine(return scope const char[] line)
+{
+    auto parts = line.stripRight.splitter!(c => c == ' ' || c == '=')
+        .filter!(p => !p.empty);
+    auto key = parts.front;
+    parts.popFront;
+    auto val = parts.front;
+    return tuple(key, val);
+}
 
-    JSONValue aws = jv.object["aws"];
+Config loadConfig(string awsProfile)
+{
     Config c;
-    c.aws_key    = aws.object["key"].str;
-    c.aws_secret = aws.object["secret"].str;
-    c.aws_endpoint = aws.object["endpoint"].str;
 
-    c.s3_bucket = jv.object["s3bucket"].str;
+    immutable home = environment["HOME"];
+
+    foreach (key, val; getIniSection(home~"/.aws/credentials", "["~awsProfile~"]"))
+    {
+        if (key == "aws_access_key_id")
+            c.aws_key = val.idup;
+        else if (key == "aws_secret_access_key")
+            c.aws_secret = val.idup;
+    }
+    enforce(!c.aws_key.empty && !c.aws_secret.empty, "Failed to parse key and secret from ~/.aws/credentials.");
+
+    foreach (key, val; getIniSection(home~"/.aws/config", "[profile "~awsProfile~"]"))
+    {
+        if (key == "region")
+            c.aws_endpoint = "s3-%s.amazonaws.com".format(val);
+    }
+    enforce(!c.aws_endpoint.empty, "Failed to parse region from ~/.aws/config.");
+
     return c;
 }
-


### PR DESCRIPTION
- avoids the need for a redundant config file
- implemented for https://github.com/dlang/ci/pull/324